### PR TITLE
Fix bug with column types of summarize operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,30 +82,55 @@ The below code exemplifies how to use the `DataFrame` class to perform data crun
     }
 
     int main (int argc, char *argv[]) {
+        // load the data
         auto df_person = getPersonData(); 
+
+        // create a new column with a computed value
         auto df_bmi = df_person.apply<"bmi">([](dacr_param) { 
             return (
                 static_cast<double>(dacr_value("weight_in_kg")) / 
                 (dacr_value("size_in_m") * dacr_value("size_in_m"))
             );
         });
-        auto df_bmi_below_60 = df_bmi.query([](dacr_param) {
+
+        // filter rows by custom lambda function
+        auto df_bmi_for_below_60_years = df_bmi.query([](dacr_param) {
             return dacr_value("age") < 60;
         });
         
-        auto df_city = getCityData();  
-        auto df_join_with_city = df_bmi_below_60.join<dacr::Join::Inner, "city">(df_city);
+        // load second dataset
+        auto df_city = getCityData();
+
+        // join the two dataframes to a single data frame
+        auto df_join_with_city = df_bmi_for_below_60_years.join<dacr::Join::Inner, "city">(df_city);
+
+        // compute summarizations with group-by
         auto df_summarize = df_join_with_city.summarize<
             dacr::GroupBy<"country">,
             dacr::Avg<"bmi", "bmi_avg">
         >();
 
+        // sort the dataframe
         auto df_summarize_sorted = df_summarize.sortBy<dacr::SortOrder::Ascending, "country">();
 
+        // print the dataframe
         df_summarize_sorted.print({
+            .fixedpoint_precision = 4,
             .string_width = 20,
         });
     }
+
+The output of running this example is:
+
+    |------------------------------------|
+    | country              |     bmi_avg |
+    |------------------------------------|
+    | Canada               |     39.3929 |
+    | Germany              |     26.1224 |
+    | Japan                |     20.2812 |
+    | South Korea          |     19.3906 |
+    | USA                  |     29.6495 |
+    |------------------------------------|
 
 
 ## NamedTuple

--- a/tests/internal/dataframe_summarize.test.cpp
+++ b/tests/internal/dataframe_summarize.test.cpp
@@ -90,89 +90,117 @@ TEST(DataFrameSummarize, AreValidSummarizeOps) {
 }
 
 TEST(DataFrameSummarize, GetColumnForOp) {
+    // Operation: Sum
     EXPECT_TRUE((std::is_same_v<
         GetColumnForOp<Sum<"a", "a_sum">, Column<"a", int>>,
         Column<"a_sum", int>
     >));
 
+    // Operation: Min
     EXPECT_TRUE((std::is_same_v<
         GetColumnForOp<Min<"a", "a_min">, Column<"a", int>>,
         Column<"a_min", int>
     >));
 
+    // Operation: Max
     EXPECT_TRUE((std::is_same_v<
         GetColumnForOp<Max<"a", "a_max">, Column<"a", int>>,
         Column<"a_max", int>
     >));
 
+    // Operation: Avg
     EXPECT_TRUE((std::is_same_v<
         GetColumnForOp<Avg<"a", "a_avg">, Column<"a", int>>,
         Column<"a_avg", int>
     >));
 
+    // Operation: StdDev
     EXPECT_TRUE((std::is_same_v<
         GetColumnForOp<StdDev<"a", "a_stddev">, Column<"a", int>>,
         Column<"a_stddev", int>
     >));
 
+    // Operation: CountIf
     EXPECT_TRUE((std::is_same_v<
-        GetColumnForOp<CountIf<"a", "a_cntif">, Column<"a", int>>,
+        GetColumnForOp<CountIf<"a", "a_cntif">, Column<"a", bool>>,
         Column<"a_cntif", int>
     >));
 
+    // Operation: CountIfNot
     EXPECT_TRUE((std::is_same_v<
-        GetColumnForOp<CountIfNot<"a", "a_cntifnot">, Column<"a", int>>,
+        GetColumnForOp<CountIfNot<"a", "a_cntifnot">, Column<"a", bool>>,
         Column<"a_cntifnot", int>
     >));
 }
 
 TEST(DataFrameSummarize, GetNewColumnsForOps) {
     EXPECT_TRUE((std::is_same_v<
-        GetNewColumnsForOps<TypeList<CountIf<"a", "a_cntif">>, Column<"a", int>>,
-        TypeList<Column<"a_cntif", int>>
+        GetNewColumnsForOps<TypeList<CountIf<"a", "a_cntif">>, Column<"a", bool>>,
+        TypeList<Column<"a_cntif", bool>>
     >));
 
     EXPECT_TRUE((std::is_same_v<
-        GetNewColumnsForOps<TypeList<CountIf<"a", "a_cntif">, Max<"a", "a_max">>, Column<"a", int>>,
-        TypeList<Column<"a_cntif", int>, Column<"a_max", int>>
+        GetNewColumnsForOps<TypeList<CountIf<"a", "a_cntif">, Max<"a", "a_max">>, Column<"a", bool>>,
+        TypeList<Column<"a_cntif", bool>, Column<"a_max", int>>
     >));
 }
 
 TEST(DataFrameSummarizer, GetSummarizerForOp) {
+    // Operation: Min
+    using SummarizerForMin = GetSummarizerForOp<Min<"a", "a_min">, Column<"a", int>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<Min<"a", "a_min">, Column<"a", int>>,
+        SummarizerForMin,
         SummarizerMin<0, int>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForMin::TargetType, int>));
 
+    // Operation: Max
+    using SummarizerForMax = GetSummarizerForOp<Max<"a", "a_max">, Column<"0", double>, Column<"a", float>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<Max<"a", "a_max">, Column<"0", double>, Column<"a", float>>,
+        SummarizerForMax,
         SummarizerMax<1, float>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForMax::TargetType, float>));
 
+    // Operation: Sum
+    using SummarizerForSum = GetSummarizerForOp<Sum<"a", "a_sum">, Column<"0", double>, Column<"a", short>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<Sum<"a", "a_sum">, Column<"0", double>, Column<"a", short>>,
+        SummarizerForSum,
         SummarizerSum<1, short>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForSum::TargetType, short>));
 
+    // Operation: Avg
+    using SummarizerForAvg = GetSummarizerForOp<Avg<"a", "a_avg">, Column<"a", int>, Column<"0", double>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<Avg<"a", "a_avg">, Column<"a", int>, Column<"0", double>>,
+        SummarizerForAvg,
         SummarizerAvg<0, int>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForAvg::TargetType, double>));
 
+    // Operation: StdDev
+    using SummarizerForStdDev = GetSummarizerForOp<StdDev<"a", "a_stddev">, Column<"a", int>, Column<"0", double>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<StdDev<"a", "a_stddev">, Column<"a", int>, Column<"0", double>>,
+        SummarizerForStdDev,
         SummarizerStdDev<0, int>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForStdDev::TargetType, double>));
 
+    // Operation: CountIf
+    using SummarizerForCountIf = GetSummarizerForOp<CountIf<"a", "a_cntif">, Column<"a", bool>, Column<"b", float>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<CountIf<"a", "a_cntif">, Column<"a", bool>, Column<"b", float>>,
+        SummarizerForCountIf,
         SummarizerCountIf<0, bool>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForCountIf, int>));
 
+    // Operation: CountIfNot
+    using SummarizerForCountIfNot = GetSummarizerForOp<CountIfNot<"a", "a_cntifnot">, Column<"0", double>, Column<"a", bool>>;
     EXPECT_TRUE((std::is_same_v<
-        GetSummarizerForOp<CountIfNot<"a", "a_cntifnot">, Column<"0", double>, Column<"a", bool>>,
+        SummarizerForCountIfNot,
         SummarizerCountIfNot<1, bool>
     >));
+    EXPECT_TRUE((std::is_same_v<SummarizerForCountIfNot, int>));
 }
 
 TEST(DataFrameSummarize, GetCompoundSummarizer) {


### PR DESCRIPTION
The column types for summarized columns were incorrectly deduced for Avg and StdDev operations. As a side-effect the formatting of the table has been improved for floating point columns.