### PR TITLE
Set further restrictions on the column types for the DataFrame

### DIFF
--- a/docs/api/dataframe.md
+++ b/docs/api/dataframe.md
@@ -9,7 +9,9 @@ nav_order: 2
 {:toc}
 
 The class `DataFrame` is an in-memory data storage providing essential operations for data processing, filtering and analysis.
-A `DataFrame` is composed of a set of columns with each column having a `name` and a `type`:
+A `DataFrame` is composed of a set of columns with each column having a `name` and a `type`.
+The `type` must be a plain data type, i.e. no reference or cv-qualified type.
+Custom data types however are supported if they are default, move and copy constructible.
 
 ```cpp
 using Column = dacr::Column<"name", type>;

--- a/include/data_crunching/internal/column.hpp
+++ b/include/data_crunching/internal/column.hpp
@@ -42,7 +42,15 @@ struct IsColumnImpl<FirstType, RestTypes...> : std::false_type {};
 
 template <FixedString FirstName, typename FirstType, typename ...RestColumns>
 struct IsColumnImpl<Column<FirstName, FirstType>, RestColumns...> {
-    static constexpr bool value = IsColumnImpl<RestColumns...>::value;
+    static constexpr bool value = (
+        !std::is_reference_v<FirstType> && 
+        !std::is_const_v<FirstType> && 
+        !std::is_volatile_v<FirstType> &&
+        std::is_default_constructible_v<FirstType> &&
+        std::is_copy_constructible_v<FirstType> &&
+        std::is_move_constructible_v<FirstType> &&
+        IsColumnImpl<RestColumns...>::value
+    );
 };
 
 template <typename T>

--- a/tests/internal/column.test.cpp
+++ b/tests/internal/column.test.cpp
@@ -26,6 +26,13 @@ using namespace dacr::internal;
 
 TEST(Column, IsColumn) {
     EXPECT_TRUE((is_column<dacr::Column<"name", int>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", int&>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", const int>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", const int&>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", volatile int>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", volatile int&>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", volatile const int>>));
+    EXPECT_FALSE((is_column<dacr::Column<"name", volatile const int&>>));
 }
 
 TEST(Column, NotIsColumn) {


### PR DESCRIPTION
Additional restrictions are set (in code and documentation) for the permitted data types of the `DataFrame`. In specific, the given data types must be default, move and copy constructible and must not be references, const- or volatile-qualified data types. 