### PR TITLE
Add structured bindings for NamedTuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ int main (int argc, char*argv[]) {
 
     // access to members
     namedtuple3.get<"a">() = 2.0 * namedtuple3.get<"d">();
+
+    // structured bindings
+    auto [a, d] = namedtuple3;
 }
 ```
 

--- a/docs/api/namedtuple.md
+++ b/docs/api/namedtuple.md
@@ -52,6 +52,7 @@ auto point3d_by_field_literals = dacr::NamedTuple("x"_field = 1.0, "y"_field = -
 auto point3d_by_field_macro = dacr::NamedTuple(dacr_field("x") = 1.0, dacr_field("y") = -1.0, dacr_field("z") = 0.5);
 ```
 
+
 ## Member Access
 
 The members of the `NamedTuple` may be accessed for read and write by the `get` template function:
@@ -60,4 +61,15 @@ The members of the `NamedTuple` may be accessed for read and write by the `get` 
 auto x = point.get<"x">();
 
 point.get<"x">() = 2.0;
+```
+
+
+## Structured Bindings
+
+The `NamedTuple` may also be used with structured bindings:
+
+```cpp
+auto tuple = dacr::NamedTuple("i"_field = 1, "d"_field = 2.0);
+
+const auto& [i, d] = tuple;
 ```

--- a/examples/namedtuple.cpp
+++ b/examples/namedtuple.cpp
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #include <data_crunching/namedtuple.hpp>
+#include <iostream>
 
 int main (int argc, char*argv[]) {
     // variant 1: NamedTuple definition
@@ -27,4 +28,7 @@ int main (int argc, char*argv[]) {
 
     // access to members
     namedtuple3.get<"a">() = 2.0 * namedtuple3.get<"d">();
+
+    // structured bindings
+    auto [a, d] = namedtuple3;
 }

--- a/tests/internal/namedtuple.test.cpp
+++ b/tests/internal/namedtuple.test.cpp
@@ -40,3 +40,15 @@ TEST(NamedTupleInternal, GetFieldIndexByName) {
     EXPECT_EQ((get_field_index_by_name<"int", Field<"int", int>, Field<"dbl", double>>), 0);
     EXPECT_EQ((get_field_index_by_name<"dbl", Field<"int", int>, Field<"dbl", double>>), 1);
 } 
+
+TEST(NamedTupleInternal, GetTypeFromFieldsByIndex) {
+    EXPECT_TRUE((std::is_same_v<
+        GetTypeFromFieldsByIndex<0, Field<"int", int>, Field<"dbl", double>>,
+        int
+    >));
+
+    EXPECT_TRUE((std::is_same_v<
+        GetTypeFromFieldsByIndex<1, Field<"int", int>, Field<"dbl", double>>,
+        double
+    >));
+}

--- a/tests/namedtuple.test.cpp
+++ b/tests/namedtuple.test.cpp
@@ -51,3 +51,42 @@ TEST(NamedTuple, NamedTupleConstructionExplicit) {
     EXPECT_EQ(namedtuple.get<"int">(), 10);
     EXPECT_EQ(namedtuple.get<"dbl">(), 20.0);
 }
+
+struct CustomData {
+    int i;
+    double d;
+};
+
+TEST(NamedTuple, StructuredBindings) {
+    auto tuple = dacr::NamedTuple("i"_field = 10, "custom"_field = CustomData{100, 200.0});
+    auto& [i, custom] = tuple;
+
+    i = 1;
+    custom.i = 2;
+    custom.d = 3.0;
+
+    EXPECT_EQ(tuple.get<"i">(), 1);
+    EXPECT_EQ(tuple.get<"custom">().i, 2);
+    EXPECT_DOUBLE_EQ(tuple.get<"custom">().d, 3.0);
+}
+
+TEST(NamedTuple, StructuredBindingsConst) {
+    auto tuple = dacr::NamedTuple("i"_field = 10, "custom"_field = CustomData{100, 200.0});
+    const auto& [i, custom] = tuple;
+
+    EXPECT_EQ(i, 10);
+    EXPECT_EQ(custom.i, 100);
+    EXPECT_DOUBLE_EQ(custom.d, 200.0);
+}
+
+TEST(NamedTuple, StructuredBindingsMove) {
+    auto tuple = dacr::NamedTuple("i"_field = 10, "custom"_field = CustomData{100, 200.0});
+    auto&& [i, custom] = std::move(tuple);
+
+    auto moved_to_i = std::move(i);
+    auto moved_to_custom = std::move(custom);
+
+    EXPECT_EQ(moved_to_i, 10);
+    EXPECT_EQ(moved_to_custom.i, 100);
+    EXPECT_DOUBLE_EQ(moved_to_custom.d, 200.0);
+}


### PR DESCRIPTION
The `std::tuple` can be used with structured bindings. This feature is also enabled for `NamedTuple`.